### PR TITLE
feat: onViolation callback

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,10 +32,13 @@
     "@rdfjs/to-ntriples": "^2.0.0",
     "assert-throws-async": "^3.0.0",
     "c8": "^7.10.0",
+    "chai": "^4.3.4",
     "get-stream": "^6.0.1",
     "mocha": "^9.1.2",
     "rdf-utils-fs": "^2.2.0",
     "readable-stream": "^3.6.0",
+    "sinon": "^12.0.1",
+    "sinon-chai": "^3.7.0",
     "stricter-standard": "^0.2.0"
   },
   "engines": {

--- a/readme.md
+++ b/readme.md
@@ -48,6 +48,32 @@ prefix code: <https://code.described.at/>
     [ code:name "shape" ; code:value <#CubeShapes> ] ,
     # validation will stop when the given number is reached (default 1)
     # set to 0 to report all errors    
-    [ code:name "maxErrors" ; code:value 100 ] ;
+    [ code:name "maxErrors" ; code:value 100 ] ,
+    # callback function which allows pipeline authors to perform
+    # additional actions and/or decide to continue the pipeline 
+    # when SHACL violations are encountered (see below)
+    [ 
+      code:name "onViolation" ; 
+      code:value [ a code:EcmaScriptModule ; code:link <file:...> ] ;
+    ] ;
 .
+```
+
+#### `onViolation`
+
+The function below could be used to continue the pipeline when SHACL violations are found but none of them are `sh:Violation`.
+
+```js
+import { sh } from '@tpluscode/rdf-ns-builders'
+
+/**
+* @param context {Object} Pipeline context
+* @param data {DatasetCore} Data graph which failed validation
+* @param report {ValidationReport}
+*/
+export function continueOnWarnings({ context, data, report }) {
+    const hasViolations = report.results.some(({ severity }) => severity.equals(sh.Violation))
+
+    return !hasViolations
+}
 ```

--- a/test/validate.test.js
+++ b/test/validate.test.js
@@ -7,8 +7,12 @@ import { isReadableStream, isWritableStream } from 'is-stream'
 import { describe, it } from 'mocha'
 import pkg from 'rdf-dataset-ext'
 import rdf from 'rdf-ext'
+import chai, {expect} from 'chai'
+import sinon from 'sinon'
+import sinonChai from "sinon-chai"
 import { shacl } from '../validate.js'
 
+chai.use(sinonChai);
 const { toStream } = pkg
 
 const shapePath = 'support/simple.shape.ttl'
@@ -90,6 +94,29 @@ describe('validate-shacl', () => {
       await assertThrows(async () => {
         await getStream.array(validatedInput)
       }, Error, /More than 1 values/)
+    })
+
+    it('does not fail when there are validation errors but callback returns true', async () => {
+      const data = await getRDFDataset('support/data.ttl')
+      const wrongData = await getRDFDataset('support/wrong-data.ttl')
+      const dataset = [data, data, wrongData, data]
+      const onViolation = sinon.stub().returns(true)
+      const context = {}
+
+      // Assumes partitioned data is sent through
+      const validator = await shacl.call(context, {
+        shape: getRDFStream(shapePath),
+        onViolation
+      })
+      const validatedInput = toStream(dataset).pipe(validator)
+
+      const passedTrough = await getStream.array(validatedInput)
+      strictEqual(passedTrough.length, dataset.length)
+      expect(onViolation).to.have.been.calledWithMatch({
+        context,
+        data: wrongData,
+        report: sinon.match.object
+      })
     })
   })
 })

--- a/test/validate.test.js
+++ b/test/validate.test.js
@@ -2,17 +2,17 @@ import assert, { strictEqual } from 'assert'
 import fs from 'fs'
 import ParserN3 from '@rdfjs/parser-n3'
 import assertThrows from 'assert-throws-async'
+import chai, { expect } from 'chai'
 import getStream from 'get-stream'
 import { isReadableStream, isWritableStream } from 'is-stream'
 import { describe, it } from 'mocha'
 import pkg from 'rdf-dataset-ext'
 import rdf from 'rdf-ext'
-import chai, {expect} from 'chai'
 import sinon from 'sinon'
-import sinonChai from "sinon-chai"
+import sinonChai from 'sinon-chai'
 import { shacl } from '../validate.js'
 
-chai.use(sinonChai);
+chai.use(sinonChai)
 const { toStream } = pkg
 
 const shapePath = 'support/simple.shape.ttl'

--- a/validate.js
+++ b/validate.js
@@ -23,7 +23,7 @@ class ValidateChunk extends Transform {
       shouldContinue = this.onViolation({
         context: this.context,
         report,
-        data,
+        data
       })
     }
 

--- a/validate.js
+++ b/validate.js
@@ -5,22 +5,34 @@ import { Transform } from 'readable-stream'
 import { buildErrorMessage } from './lib/buildErrorMessage.js'
 
 class ValidateChunk extends Transform {
-  constructor (shape, { maxErrors } = {}) {
+  constructor (context, shape, { maxErrors, onViolation } = {}) {
     super({
       writableObjectMode: true,
       readableObjectMode: true
     })
+    this.context = context
+    this.onViolation = onViolation
     this.validator = new SHACLValidator(shape, { maxErrors })
   }
 
-  _transform (chunk, encoding, callback) {
-    const report = this.validator.validate(chunk)
-    if (!report.conforms) {
-      const errorMessage = buildErrorMessage(report)
-      this.destroy(new Error(errorMessage))
-    } else {
-      callback(null, chunk)
+  _transform (data, encoding, callback) {
+    const report = this.validator.validate(data)
+    let shouldContinue = report.conforms
+
+    if (!shouldContinue && typeof this.onViolation === 'function') {
+      shouldContinue = this.onViolation({
+        context: this.context,
+        report,
+        data,
+      })
     }
+
+    if (shouldContinue) {
+      return callback(null, data)
+    }
+
+    const errorMessage = buildErrorMessage(report)
+    this.destroy(new Error(errorMessage))
   }
 }
 
@@ -42,5 +54,5 @@ export async function shacl (arg) {
     throw new Error(`${shape} is not a readable stream`)
   }
 
-  return new ValidateChunk(await rdf.dataset().import(shape), { maxErrors })
+  return new ValidateChunk(this, await rdf.dataset().import(shape), { ...options, maxErrors })
 }


### PR DESCRIPTION
Merge after #5

I added a callback parameter which will be called when a failed report will be returned by the violation

It will receive three values:

1. Pipeline `context`, useful to access logger or variables
2. The actual failed `data`, might use it to modify the data before pushing it down the line
3. The `report` itself, to inspect or handle the results