### PR TITLE
feat: provide validation report on error object

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,4 +1,4 @@
-export function buildErrorMessage (report) {
+function buildErrorMessage (report) {
   return JSON.stringify(report.results.map(x => {
     const result = {}
     if (x.message && x.message.length > 0) {
@@ -16,4 +16,13 @@ export function buildErrorMessage (report) {
     result.sourceConstraintComponent = x.sourceConstraintComponent.value
     return result
   }))
+}
+
+export class ValidationError extends Error {
+  constructor (report) {
+    const message = buildErrorMessage(report)
+    super(message)
+
+    this.report = report
+  }
 }

--- a/validate.js
+++ b/validate.js
@@ -2,7 +2,7 @@ import { isStream, isReadableStream } from 'is-stream'
 import rdf from 'rdf-ext'
 import SHACLValidator from 'rdf-validate-shacl'
 import { Transform } from 'readable-stream'
-import { buildErrorMessage } from './lib/buildErrorMessage.js'
+import { ValidationError } from './lib/errors.js'
 
 class ValidateChunk extends Transform {
   constructor (context, shape, { maxErrors, onViolation } = {}) {
@@ -31,8 +31,7 @@ class ValidateChunk extends Transform {
       return callback(null, data)
     }
 
-    const errorMessage = buildErrorMessage(report)
-    this.destroy(new Error(errorMessage))
+    this.destroy(new ValidationError(report))
   }
 }
 


### PR DESCRIPTION
It is sometimes useful to have access to the full `ValidationReport` when handling the error.